### PR TITLE
Attempting to use bluetooth headset as audio source when recording

### DIFF
--- a/flutter_sound/android/build.gradle
+++ b/flutter_sound/android/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     // CAUTION: The following instruction is for developping and debugging the Flauto Engine
     // DO NOT INCLUDE THE FOLLOWING LINE IN A REAL APP !!!
     //implementation project(':flutter_sound_core')
-    implementation 'com.github.canardoux:flutter_sound_core:9.2.13'
     // -------------------------------------------------------------------------------------
 
 }

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/Flauto.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/Flauto.java
@@ -1,0 +1,132 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import android.app.Activity;
+import android.content.Context;
+
+import java.io.File;
+//import androidx.annotation.NonNull;
+
+
+
+public class Flauto
+{
+
+	public enum t_CODEC
+	{
+		defaultCodec,
+		aacADTS,
+		opusOGG,
+		opusCAF, // Apple encapsulates its bits in its own special envelope : .caf instead of a regular ogg/opus (.opus). This is completely stupid, this is Apple.
+		mp3,
+		vorbisOGG,
+		pcm16,
+		pcm16WAV,
+		pcm16AIFF,
+		pcm16CAF,
+		flac,
+		aacMP4,
+		amrNB,
+		amrWB,
+		pcm8,
+		pcmFloat32,
+		pcmWebM,
+		opusWebM,
+		vorbisWebM,
+	}
+
+
+
+	public enum t_PLAYER_STATE
+	{
+		PLAYER_IS_STOPPED,
+		PLAYER_IS_PLAYING,
+		PLAYER_IS_PAUSED
+	}
+
+
+	public enum t_RECORDER_STATE
+	{
+		RECORDER_IS_STOPPED,
+		RECORDER_IS_PAUSED,
+		RECORDER_IS_RECORDING,
+	}
+
+
+
+
+
+	public enum t_AUDIO_SOURCE
+	{
+		defaultSource,
+		microphone,
+		voiceDownlink, // (if someone can explain me what it is, I will be grateful ;-) )
+		camCorder,
+		remote_submix,
+		unprocessed,
+		voice_call,
+		voice_communication,
+		voice_performance,
+		voice_recognition,
+		voiceUpLink,
+		bluetoothHFP,
+		headsetMic,
+		lineIn
+	}
+
+
+
+	public enum t_LOG_LEVEL
+	{
+				VERBOSE,
+				DBG,
+				INFO,
+				WARNING,
+				ERROR,
+				WTF,
+				NOTHING,
+	}
+
+
+
+
+	public static Activity androidActivity;
+	public static Context androidContext;
+
+	public static String temporayFile(String radical)
+	{
+		File outputDir = Flauto.androidContext.getCacheDir(); // context being the Activity pointer
+		return outputDir + "/" + radical;
+
+	}
+
+	public static String getPath(String path)
+	{
+		if (path == null)
+			return null;
+		boolean isFound = path.contains("/");
+		if (!isFound)
+		{
+			path = temporayFile(path);
+		}
+		return path;
+	}
+
+}

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoMediaPlayer.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoMediaPlayer.java
@@ -1,0 +1,144 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import android.media.MediaPlayer;
+
+//-------------------------------------------------------------------------------------------------------------
+
+
+
+class FlautoMediaPlayer extends FlautoPlayerEngineInterface
+{
+	MediaPlayer mediaPlayer = null;
+	FlautoPlayer flautoPlayer;
+
+	void _startPlayer(String path, int sampleRate, int numChannels, int blockSize, FlautoPlayer theSession) throws Exception
+ 	{
+ 		mediaPlayer = new MediaPlayer();
+		if (path == null)
+		{
+			throw new Exception("path is NULL");
+		}
+		this.flautoPlayer = theSession;
+		mediaPlayer.setDataSource(path);
+		final String pathFile = path;
+		mediaPlayer.setOnPreparedListener(mp -> {flautoPlayer.play(); flautoPlayer.onPrepared();});
+		mediaPlayer.setOnCompletionListener(mp -> flautoPlayer.onCompletion());
+		mediaPlayer.setOnErrorListener(flautoPlayer);
+		mediaPlayer.prepare(); // Maybe too early. Should be after start()
+	}
+
+	void _play()
+	{
+		mediaPlayer.start();
+	}
+
+	int feed(byte[] data) throws Exception
+	{
+		throw new Exception("Cannot feed a Media Player");
+	}
+
+	void _setVolume(double volume)
+	{
+		float v = (float)volume;
+		mediaPlayer.setVolume ( v, v );
+	}
+
+	void _setSpeed(double speed)
+	{
+		float v = (float)speed;
+	}
+
+	void _stop() {
+		if (mediaPlayer == null)
+		{
+			return;
+		}
+
+		try
+		{
+			mediaPlayer.stop();
+		} catch (Exception e)
+		{
+		}
+
+		try
+		{
+			mediaPlayer.reset();
+		} catch (Exception e)
+		{
+		}
+
+		try
+		{
+			mediaPlayer.release();
+		} catch (Exception e)
+		{
+		}
+		mediaPlayer = null;
+
+	}
+
+	void _finish() { // NO-OP
+	}
+
+
+
+	void _pausePlayer() throws Exception {
+		if (mediaPlayer == null) {
+			throw new Exception("pausePlayer()");
+		}
+		mediaPlayer.pause();
+	}
+
+	void _resumePlayer() throws Exception {
+		if (mediaPlayer == null) {
+			throw new Exception("resumePlayer");
+		}
+
+		if (mediaPlayer.isPlaying()) {
+			throw new Exception("resumePlayer");
+		}
+		// Is it really good ? // mediaPlayer.seekTo ( mediaPlayer.getCurrentPosition () );
+		mediaPlayer.start();
+	}
+
+	void _seekTo(long millisec)
+	{
+		mediaPlayer.seekTo ( (int)millisec );
+	}
+
+	boolean _isPlaying()
+	{
+		return mediaPlayer.isPlaying ();
+	}
+
+	long _getDuration()
+	{
+		return mediaPlayer.getDuration();
+	}
+
+	long _getCurrentPosition()
+	{
+		return mediaPlayer.getCurrentPosition();
+	}
+}
+
+//-------------------------------------------------------------------------------------------------------------

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoPlayer.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoPlayer.java
@@ -1,0 +1,578 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+
+import android.media.MediaPlayer;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+
+import android.media.AudioFocusRequest;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.lang.Thread;
+
+import com.dooboolab.TauEngine.Flauto.*;
+import com.dooboolab.TauEngine.Flauto;
+
+public class FlautoPlayer  implements MediaPlayer.OnErrorListener
+{
+
+	static boolean _isAndroidDecoderSupported[] = {
+		true, // DEFAULT
+		true, // aacADTS				// OK
+		Build.VERSION.SDK_INT >= 23, // opusOGG	// (API 29 ???)
+		false, // opusCAF				/
+		true, // MP3					// OK
+		true, //Build.VERSION.SDK_INT >= 23, // vorbisOGG// OK
+		true, // pcm16
+		true, // pcm16WAV				// OK
+		true, // pcm16AIFF				// OK
+		false, // pcm16CAF				// NOK
+		true, // flac					// OK
+		true, // aacMP4					// OK
+		true, // amrNB					// OK
+		true, // amrWB					// OK
+		false, // pcm8
+		false, // pcmFloat32
+		false, // pcmWebM
+		true, // opusWebM
+		true, // vorbisWebM
+	};
+
+
+	String extentionArray[] = {
+		  ".aac" // DEFAULT
+		, ".aac" // CODEC_AAC
+		, ".opus" // CODEC_OPUS
+		, "_opus.caf" // CODEC_CAF_OPUS (this is apple specific)
+		, ".mp3" // CODEC_MP3
+		, ".ogg" // CODEC_VORBIS
+		, ".pcm" // CODEC_PCM
+		, ".wav"
+		, ".aiff"
+		, "._pcm.caf"
+		, ".flac"
+		, ".mp4"
+		, ".amr" // amrNB
+		, ".amr" // amrWB
+		, ".pcm" // pcm8
+		, ".pcm" // pcmFloat323
+		, ".webm" // pcmWebM
+		, ".opus" // opusWebM
+		, ".vorbis" // vorbisWebM
+	};
+
+
+
+
+	final static  String           TAG         = "FlautoPlayer";
+	long subsDurationMillis = 0;
+	FlautoPlayerEngineInterface player;
+	private       Timer            mTimer   ;
+	final private Handler          mainHandler = new Handler (Looper.getMainLooper ());
+	boolean pauseMode;
+	FlautoPlayerCallback m_callBack;
+	public		t_PLAYER_STATE 		playerState = t_PLAYER_STATE.PLAYER_IS_STOPPED;
+	private double latentVolume = -1.0;
+	private double latentSpeed = -1.0;
+	private long latentSeek = -1;
+	static int currentPlayerID = 0;
+	private int myPlayerId = 0;
+
+
+	static final String ERR_UNKNOWN           = "ERR_UNKNOWN";
+	static final String ERR_PLAYER_IS_NULL    = "ERR_PLAYER_IS_NULL";
+	static final String ERR_PLAYER_IS_PLAYING = "ERR_PLAYER_IS_PLAYING";
+
+	/* ctor */ public FlautoPlayer(FlautoPlayerCallback callBack)
+	{
+		m_callBack = callBack;
+	}
+
+
+	private String getTempFileName()
+	{
+		File outputDir = Flauto.androidContext.getCacheDir(); // context being the Activity pointer
+		return outputDir.getPath() + "/flutter_sound_" + myPlayerId;
+	}
+	public boolean openPlayer ()
+	{
+		++currentPlayerID;
+		myPlayerId = currentPlayerID;
+		latentVolume = -1.0;
+		latentSpeed = -1.0;
+		latentSeek = -1;
+		playerState = t_PLAYER_STATE.PLAYER_IS_STOPPED;
+		m_callBack.openPlayerCompleted(true);
+		return true;
+	}
+
+	public void closePlayer ( )
+	{
+		stop();
+		playerState = t_PLAYER_STATE.PLAYER_IS_STOPPED;
+		m_callBack.closePlayerCompleted(true);
+	}
+
+	public t_PLAYER_STATE getPlayerState()
+	{
+		if (player == null)
+			return t_PLAYER_STATE.PLAYER_IS_STOPPED;
+		if (player._isPlaying())
+		{
+			if (pauseMode)
+				throw new RuntimeException();
+			return t_PLAYER_STATE.PLAYER_IS_PLAYING;
+		}
+		return pauseMode ? t_PLAYER_STATE.PLAYER_IS_PAUSED : t_PLAYER_STATE.PLAYER_IS_STOPPED;
+	}
+
+	public boolean startPlayerFromMic (int numChannels, int sampleRate, int blockSize )
+	{
+		stop(); // To start a new clean playback
+
+		try
+		{
+			player = new FlautoPlayerEngineFromMic(this);
+			player._startPlayer(null,  sampleRate, numChannels, blockSize, this);
+			play();
+		}
+		catch ( Exception e )
+		{
+			logError ("startPlayer() exception" );
+			return false;
+		}
+		return true;
+	}
+
+	public boolean startPlayer (t_CODEC codec, String fromURI, byte[] dataBuffer, int numChannels, int sampleRate, int blockSize )
+	{
+		stop(); // To start a new clean playback
+		if (dataBuffer != null)
+		{
+			try
+			{
+				String fileName = getTempFileName();
+				deleteTempFile(); // Delete old file if exists
+				File             f   = new  File(fileName);
+				FileOutputStream fos = new FileOutputStream ( f );
+				fos.write ( dataBuffer );
+				fromURI = f.getPath();
+			}
+			catch ( Exception e )
+			{
+				return false;
+			}
+		}
+
+
+		try
+		{
+			if (fromURI == null && codec == t_CODEC.pcm16)
+			{
+				player = new FlautoPlayerEngine();
+			} else
+			{
+				player = new FlautoPlayerMedia(this);
+			}
+			String path = Flauto.getPath(fromURI);
+
+			player._startPlayer(path,  sampleRate, numChannels, blockSize, this);
+			play();
+		}
+		catch ( Exception e )
+		{
+			logError (  "startPlayer() exception" );
+			return false;
+		}
+		return true;
+	}
+
+	public int feed( byte[] data) throws  Exception
+	{
+		if (player == null)
+		{
+			throw new Exception("feed() : player is null");
+		}
+
+		try
+		{
+			int ln = player.feed(data);
+			assert (ln >= 0);
+			return ln;
+		} catch (Exception e)
+		{
+			logError (  "feed() exception" );
+			throw e;
+		}
+	}
+
+	public void needSomeFood(int ln)
+	{
+		if (ln < 0)
+			throw new RuntimeException();
+		mainHandler.post(new Runnable()
+		{
+			@Override
+			public void run()
+			{
+				m_callBack.needSomeFood(ln);
+			}
+		});
+	}
+
+
+	public boolean onError(MediaPlayer mp, int what, int extra)
+	{
+		// ... react appropriately ...
+		// The MediaPlayer has moved to the Error state, must be reset!
+		return false;
+	}
+
+
+	// listener called when media player has completed playing.
+	public void onCompletion()
+	{
+			/*
+			 * Reset player.
+			 */
+			logDebug("Playback completed.");
+			stop();
+			playerState = t_PLAYER_STATE.PLAYER_IS_STOPPED;
+			m_callBack.audioPlayerDidFinishPlaying(true);
+	}
+
+	// Listener called when media player has completed preparation.
+	public void onPrepared( )
+	{
+		logDebug ("mediaPlayer prepared and started");
+
+		mainHandler.post(new Runnable()
+		{
+			@Override
+			public void run() {
+				long duration = 0;
+				try
+				{
+					 duration = player._getDuration();
+				} catch(Exception e)
+				{
+					System.out.println(e.toString());
+				}
+				playerState = t_PLAYER_STATE.PLAYER_IS_PLAYING;
+
+				m_callBack.startPlayerCompleted(true, duration);
+			}
+		});
+		/*
+		 * Set timer task to send event to RN.
+		 */
+	}
+
+
+	public void stopPlayer ( )
+	{
+		stop();
+		playerState = t_PLAYER_STATE.PLAYER_IS_STOPPED;
+		m_callBack.stopPlayerCompleted(true);
+	}
+
+	void cancelTimer()
+	{
+		if (mTimer != null)
+			mTimer.cancel ();
+		mTimer = null;
+	}
+	void setTimer(long duration)
+	{
+		cancelTimer();
+		subsDurationMillis = duration;
+		if (player == null || duration == 0)
+			return;
+
+		if (subsDurationMillis > 0)
+		{
+			TimerTask task = new TimerTask() {
+				@Override
+				public void run() {
+					mainHandler.post(new Runnable()
+					{
+						@Override
+						public void run()
+						{
+							try
+							{
+								if (player != null)
+								{
+
+									long position = player._getCurrentPosition();
+									long duration = player._getDuration();
+									if (position > duration)
+									{
+										position = duration;
+									}
+									m_callBack.updateProgress(position, duration);
+								}
+							} catch (Exception e)
+							{
+								logDebug( "Exception: " + e.toString());
+								stopPlayer();
+							}
+						}
+					});
+
+
+				}
+			};
+
+			mTimer = new Timer();
+
+			mTimer.schedule(task, 0, duration);
+		}
+
+	}
+
+	private void deleteTempFile()
+	{
+		String fileName = getTempFileName();
+		try
+		{
+			File fdelete = new File(fileName);
+			if (fdelete.exists())
+			{
+				if (fdelete.delete())
+				{
+					logDebug("file Deleted :" + fileName);
+				} else
+				{
+					logError("Cannot delete file " + fileName);
+				}
+			}
+
+		} catch (Exception e)
+		{
+			return;
+		}
+
+	}
+
+	void stop()
+	{
+		deleteTempFile();
+		cancelTimer();
+		pauseMode = false;
+		if (player != null)
+			player._stop();
+		player = null;
+	}
+
+	public boolean play()
+	{
+			if (player == null)
+			{
+					return false;
+			}
+			try
+			{
+				if (latentVolume >= 0)
+				{
+					setVolume(latentVolume);
+				}
+				if (latentSpeed >= 0)
+				{
+					setSpeed(latentSpeed);
+				}
+				if (subsDurationMillis > 0)
+					setTimer(subsDurationMillis);
+				if (latentSeek >= 0)
+				{
+					seekToPlayer(latentSeek);
+				}
+
+
+			}catch (Exception e)
+			{
+
+			}
+			player._play();
+			return true;
+	}
+
+	public boolean isDecoderSupported (t_CODEC codec )
+	{
+		return _isAndroidDecoderSupported[ codec.ordinal() ];
+	}
+
+	public boolean pausePlayer (  )
+	{
+		try
+		{
+			cancelTimer();
+			if (player == null)
+			{
+				m_callBack.resumePlayerCompleted(false);
+				return false;
+			}
+			player._pausePlayer();
+			pauseMode = true;
+			playerState = t_PLAYER_STATE.PLAYER_IS_PAUSED;
+			m_callBack.pausePlayerCompleted(true);
+
+			return true;
+		}
+		catch ( Exception e )
+		{
+			logError( "pausePlay exception: " + e.getMessage () );
+			return false;
+		}
+
+	}
+
+	public boolean resumePlayer (  )
+	{
+		try
+		{
+			if (player == null)
+			{
+				//m_callBack.resumePlayerCompleted(false);
+				return false;
+			}
+			player._resumePlayer();
+			pauseMode = false;
+			playerState = t_PLAYER_STATE.PLAYER_IS_PLAYING;
+			setTimer(subsDurationMillis);
+			m_callBack.resumePlayerCompleted(true);
+
+			return true;
+		}
+		catch ( Exception e )
+		{
+			logError( "mediaPlayer resume: " + e.getMessage () );
+			return false;
+		}
+	}
+
+	public boolean seekToPlayer (long millis)
+	{
+
+		if ( player == null )
+		{
+			latentSeek = millis;
+			return false;
+		}
+
+
+		logDebug("seekTo: " + millis );
+		latentSeek = -1;
+		player._seekTo ( millis );
+		return true;
+	}
+
+	public boolean setVolume ( double volume )
+	{
+		try
+		{
+
+			latentVolume = volume;
+			if (player == null) {
+				//logError( "setVolume(): player is null" );
+				return false;
+			}
+
+			//float mVolume = (float) volume;
+			player._setVolume(volume);
+			return true;
+		} catch(Exception e)
+		{
+			logError ("setVolume: " + e.getMessage () );
+			return false;
+		}
+	}
+
+
+	public boolean setSpeed ( double speed )
+	{
+		try
+		{
+
+			latentSpeed = speed;
+			if (player == null) {
+				return false;
+			}
+
+			player._setSpeed(speed);
+			return true;
+		} catch(Exception e)
+		{
+			logError ("setSpeed: " + e.getMessage () );
+			return false;
+		}
+	}
+
+
+	public void setSubscriptionDuration (long duration)
+	{
+		subsDurationMillis = duration;
+		if (player != null)
+			setTimer(subsDurationMillis);
+	}
+
+
+	public Map<String, Object> getProgress (  )
+	{
+		long position = 0;
+		long duration = 0;
+		if ( player != null ) {
+			 position = player._getCurrentPosition();
+			 duration = player._getDuration();
+		}
+		if (position > duration)
+		{
+			position = duration;
+		}
+
+		Map<String, Object> dic = new HashMap<String, Object> ();
+		dic.put ( "position", position );
+		dic.put ( "duration", duration );
+		dic.put ( "playerStatus", getPlayerState().ordinal() ); // An int because necessary with Flutter Channels
+		return dic;
+	}
+
+
+
+	void logDebug (String msg)
+	{
+		m_callBack.log ( t_LOG_LEVEL.DBG , msg);
+	}
+
+
+	void logError (String msg)
+	{
+		m_callBack.log ( t_LOG_LEVEL.ERROR , msg);
+	}
+
+}
+

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoPlayerCallback.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoPlayerCallback.java
@@ -1,0 +1,36 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import com.dooboolab.TauEngine.Flauto.*;
+
+public interface FlautoPlayerCallback
+{
+  	abstract public void openPlayerCompleted(boolean success);
+	abstract public void closePlayerCompleted(boolean success);
+	abstract public void stopPlayerCompleted(boolean success);
+	abstract public void pausePlayerCompleted(boolean success);
+	abstract public void resumePlayerCompleted(boolean success);
+	abstract public void startPlayerCompleted (boolean success, long duration);
+	abstract public void needSomeFood (int ln);
+	abstract public void updateProgress(long position, long duration);
+	abstract public void audioPlayerDidFinishPlaying (boolean flag);
+	abstract public void updatePlaybackState(t_PLAYER_STATE newState);
+	abstract public void log(t_LOG_LEVEL level, String msg);
+}

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoPlayerEngine.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoPlayerEngine.java
@@ -1,0 +1,250 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+
+import android.content.Context;
+import android.media.AudioAttributes;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioTrack;
+import android.os.Build;
+import android.os.SystemClock;
+import java.lang.Thread;
+
+
+//-------------------------------------------------------------------------------------------------------------
+
+
+
+class FlautoPlayerEngine extends FlautoPlayerEngineInterface
+{
+	AudioTrack audioTrack = null;
+	int sessionId = 0;
+	long mPauseTime = 0;
+	long mStartPauseTime = -1;
+	long systemTime = 0;
+	WriteBlockThread blockThread = null;
+	FlautoPlayer mSession = null;
+
+	class WriteBlockThread extends Thread
+	{
+		byte[] mData = null;
+		/* ctor */ WriteBlockThread(byte[] data)
+		{
+			mData = data;
+		}
+		public void run()
+		{
+			int ln =  mData.length;
+			int total = 0;
+			int written = 0;
+			while (audioTrack != null && ln > 0)
+			{
+				try
+				{
+					if (Build.VERSION.SDK_INT >= 23) {
+						written = audioTrack.write(mData, 0, ln, AudioTrack.WRITE_BLOCKING);
+					} else {
+						written = audioTrack.write(mData, 0, mData.length);
+					}
+					if (written > 0) {
+						ln -= written;
+						total += written;
+					}
+				} catch (Exception e )
+				{
+					System.out.println(e.toString());
+					return;
+				}
+			}
+			if (total < 0)
+				throw new RuntimeException();
+
+			mSession.needSomeFood(total);
+			blockThread = null;
+
+		}
+	}
+
+	/* ctor */ FlautoPlayerEngine() throws Exception
+	{
+		if ( Build.VERSION.SDK_INT >= 21 )
+		{
+
+			AudioManager audioManager = (AudioManager) Flauto.androidContext.getSystemService(Context.AUDIO_SERVICE);
+			sessionId = audioManager.generateAudioSessionId();
+		} else
+		{
+			throw new Exception("Need SDK 21");
+		}
+	}
+
+
+	void _startPlayer
+		(
+			String path,
+			int sampleRate,
+			int numChannels,
+			int blockSize,
+			FlautoPlayer theSession
+		) throws Exception
+	{
+		if ( Build.VERSION.SDK_INT >= 21 )
+		{
+			mSession = theSession;
+			AudioAttributes attributes = new AudioAttributes.Builder()
+				.setLegacyStreamType(AudioManager.STREAM_MUSIC)
+				.setUsage(AudioAttributes.USAGE_MEDIA)
+				.setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+				.build();
+
+			AudioFormat format = new AudioFormat.Builder()
+				.setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+				.setSampleRate(sampleRate)
+				.setChannelMask(numChannels == 1 ? AudioFormat.CHANNEL_OUT_MONO : AudioFormat.CHANNEL_OUT_STEREO)
+				.build();
+			audioTrack = new AudioTrack(attributes, format, blockSize, AudioTrack.MODE_STREAM, sessionId);
+			mPauseTime = 0;
+			mStartPauseTime = -1;
+			systemTime = SystemClock.elapsedRealtime();
+
+			theSession.onPrepared(); // Maybe too early ??? Should be after _play()
+		} else
+		{
+			throw new Exception("Need SDK 21");
+		}
+	}
+
+	void _play()
+	{
+		audioTrack.play();
+
+	}
+
+
+	void _stop()
+	{
+		if (audioTrack != null)
+		{
+			audioTrack.stop();
+			audioTrack.release();
+			audioTrack = null;
+		}
+		blockThread = null;
+	}
+
+	void _finish()
+	{
+	}
+
+
+
+	void _pausePlayer() throws Exception
+	{
+		mStartPauseTime = SystemClock.elapsedRealtime ();
+		audioTrack.pause();
+	}
+
+
+	void _resumePlayer() throws Exception
+	{
+		if (mStartPauseTime >= 0)
+			mPauseTime += SystemClock.elapsedRealtime () - mStartPauseTime;
+		mStartPauseTime = -1;
+
+		audioTrack.play();
+
+	}
+
+
+	void _setVolume(double volume)  throws Exception
+	{
+
+		if ( Build.VERSION.SDK_INT >= 21 )
+		{
+			float v = (float)volume;
+			audioTrack.setVolume(v);
+		} else
+		{
+			throw new Exception("Need SDK 21");
+		}
+
+	}
+
+	void _setSpeed(double volume)  throws Exception
+	{
+
+			throw new Exception("Not implemented");
+
+	}
+
+
+
+	void _seekTo(long millisec)
+	{
+
+	}
+
+
+	boolean _isPlaying()
+	{
+		return audioTrack.getPlayState () == AudioTrack.PLAYSTATE_PLAYING;
+	}
+
+
+	long _getDuration()
+	{
+		return _getCurrentPosition(); // It would be better if we add what is in the input buffers and not still played
+	}
+
+
+	long _getCurrentPosition()
+	{
+		long time ;
+		if (mStartPauseTime >= 0)
+			time =   mStartPauseTime - systemTime - mPauseTime ;
+		else
+			time = SystemClock.elapsedRealtime() - systemTime - mPauseTime;
+		return time;
+	}
+
+
+	int feed(byte[] data) throws Exception
+	{
+		int ln = 0;
+		if ( Build.VERSION.SDK_INT >= 23 )
+		{
+			ln = audioTrack.write(data, 0, data.length, AudioTrack.WRITE_NON_BLOCKING);
+		} else
+		{
+			ln = 0;
+		}
+		if (ln == 0)
+		{
+			if (blockThread != null)
+			{
+				System.out.println("Audio packet Lost !");
+			}
+			blockThread = new WriteBlockThread(data);
+			blockThread.start();
+		}
+		return ln;
+	}
+}

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoPlayerEngineFromMic.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoPlayerEngineFromMic.java
@@ -1,0 +1,350 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+
+import android.content.Context;
+import android.media.AudioAttributes;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioRecord;
+import android.media.AudioTrack;
+import android.os.Build;
+import android.os.SystemClock;
+import android.media.MediaRecorder;
+
+import java.lang.Thread;
+
+import com.dooboolab.TauEngine.Flauto.*;
+
+//-------------------------------------------------------------------------------------------------------------
+
+
+
+class FlautoPlayerEngineFromMic extends FlautoPlayerEngineInterface
+{
+	final static String             TAG                = "EngineFromMic";
+
+
+	int[] tabCodec =
+		{
+			AudioFormat.ENCODING_DEFAULT, // DEFAULT
+			AudioFormat.ENCODING_AAC_LC, // aacADTS
+			0, // opusOGG
+			0, // opusCAF
+			AudioFormat.ENCODING_MP3, // MP3 // Not used
+			0, // vorbisOGG
+			AudioFormat.ENCODING_PCM_16BIT, // pcm16
+			AudioFormat.ENCODING_PCM_16BIT, // pcm16WAV
+			0, // pcm16AIFF
+			0, // pcm16CAF
+			0, // flac
+			0, // aacMP4
+			0, // amrNB
+			0, // amrWB
+		};
+
+
+	AudioTrack audioTrack = null;
+	int sessionId = 0;
+	long mPauseTime = 0;
+	long mStartPauseTime = -1;
+	long systemTime = 0;
+	int bufferSize = 0;
+	FlautoPlayer mSession = null;
+
+	AudioRecord recorder;
+	public              int     subsDurationMillis    = 10;
+
+	private boolean isRecording = false;
+	_pollingRecordingData thePollingThread = null;
+
+
+
+	public class _pollingRecordingData extends Thread
+	{
+
+		void _feed(byte[] data, int ln) throws Exception
+		{
+			int lnr = 0;
+			if ( Build.VERSION.SDK_INT >= 23 )
+			{
+				 lnr = audioTrack.write(data, 0, ln, AudioTrack.WRITE_NON_BLOCKING);
+			} else
+			{
+				 lnr = audioTrack.write(data, 0, ln);
+			}
+			if (lnr != ln)
+			{
+				System.out.println("feed error: some audio data are lost");
+			}
+		}
+
+		public void run()
+		{
+
+			int n = 0;
+			int r = 0;
+			byte[] byteBuffer = new byte[bufferSize];
+			while (isRecording)
+			{
+				try
+				{
+					if (Build.VERSION.SDK_INT >= 23)
+					{
+						n = recorder.read(byteBuffer, 0, bufferSize, AudioRecord.READ_BLOCKING);
+					} else
+					{
+						n = recorder.read(byteBuffer, 0, bufferSize);
+					}
+					final int ln = n;
+
+					if (n > 0)
+					{
+						r += n;
+
+						try
+						{
+							_feed(byteBuffer, ln);
+						} catch (Exception err)
+						{
+							mSession.logError("feed error" + err.getMessage());
+						}
+					} else
+					{
+						mSession.logError("feed error: ln = 0" );
+						//break;
+					}
+				} catch (Exception e)
+				{
+					System.out.println(e);
+					break;
+				}
+			}
+			thePollingThread = null; // finished for me
+		}
+
+	}
+
+
+
+
+	/* ctor */ FlautoPlayerEngineFromMic(FlautoPlayer theSession) throws Exception
+	{
+		mSession = theSession;
+		if ( Build.VERSION.SDK_INT >= 21 )
+		{
+
+			AudioManager audioManager = (AudioManager) Flauto.androidContext.getSystemService(Context.AUDIO_SERVICE);
+			sessionId = audioManager.generateAudioSessionId();
+		} else
+		{
+			throw new Exception("Need SDK 21");
+		}
+	}
+
+	void startPlayerSide(int sampleRate, Integer numChannels, int blockSize) throws Exception
+	{
+		if ( Build.VERSION.SDK_INT >= 21 )
+		{
+			AudioAttributes attributes = new AudioAttributes.Builder()
+				.setLegacyStreamType(AudioManager.STREAM_MUSIC)
+				.setUsage(AudioAttributes.USAGE_MEDIA)
+				.setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+				.build();
+
+			AudioFormat format = new AudioFormat.Builder()
+				.setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+				.setSampleRate(sampleRate)
+				.setChannelMask(numChannels == 1 ? AudioFormat.CHANNEL_OUT_MONO : AudioFormat.CHANNEL_OUT_STEREO)
+				.build();
+			audioTrack = new AudioTrack(attributes, format, blockSize, AudioTrack.MODE_STREAM, sessionId);
+			mPauseTime = 0;
+			mStartPauseTime = -1;
+			systemTime = SystemClock.elapsedRealtime();
+
+			mSession.onPrepared(); // Maybe too early. Should be after _play()
+		} else
+		{
+			throw new Exception("Need SDK 21");
+		}
+
+	}
+
+	void _play()
+	{
+		audioTrack.play();
+	}
+
+	public void startRecorderSide
+		(
+			t_CODEC codec,
+			Integer sampleRate,
+			Integer numChannels,
+			int _blockSize
+		) throws Exception
+	{
+		if ( Build.VERSION.SDK_INT < 21)
+			throw new Exception ("Need at least SDK 21");
+		int channelConfig = (numChannels == 1) ? AudioFormat.CHANNEL_IN_MONO : AudioFormat.CHANNEL_IN_STEREO;
+		int audioFormat = tabCodec[codec.ordinal()];
+		bufferSize = AudioRecord.getMinBufferSize
+			(
+				sampleRate,
+				channelConfig,
+				tabCodec[codec.ordinal()]
+			) ;// !!!!! * 2 ???
+
+
+		recorder = new AudioRecord(
+			MediaRecorder.AudioSource.MIC,
+			sampleRate,
+			channelConfig,
+			audioFormat,
+			bufferSize
+		);
+
+		if (recorder.getState() == AudioRecord.STATE_INITIALIZED)
+		{
+			recorder.startRecording();
+			isRecording = true;
+			assert (thePollingThread == null);
+			thePollingThread = new _pollingRecordingData();
+			thePollingThread.start();
+		} else
+		{
+			throw new Exception("Cannot initialize the AudioRecord");
+		}
+
+	}
+
+
+
+	void _startPlayer
+		(
+			String path,
+			int sampleRate,
+			int numChannels,
+			int blockSize,
+			FlautoPlayer aPlayer
+		) throws Exception
+	{
+		startPlayerSide(sampleRate, numChannels, blockSize);
+		startRecorderSide(Flauto.t_CODEC.pcm16, sampleRate, numChannels, blockSize);
+		mSession = aPlayer;
+
+	}
+
+
+	void _stop()
+	{
+
+		if (null != recorder)
+		{
+			try
+			{
+				recorder.stop();
+			} catch ( Exception e )
+			{
+			}
+
+			try
+			{
+				isRecording = false;
+				recorder.release();
+			} catch ( Exception e )
+			{
+			}
+			recorder = null;
+		}
+
+		if (audioTrack != null)
+		{
+			audioTrack.stop();
+			audioTrack.release();
+			audioTrack = null;
+		}
+	}
+
+	void _finish()
+	{
+	}
+
+
+
+	void _pausePlayer() throws Exception
+	{
+		mStartPauseTime = SystemClock.elapsedRealtime ();
+		audioTrack.pause();
+	}
+
+
+	void _resumePlayer() throws Exception
+	{
+		if (mStartPauseTime >= 0)
+			mPauseTime += SystemClock.elapsedRealtime () - mStartPauseTime;
+		mStartPauseTime = -1;
+
+		audioTrack.play();
+
+	}
+
+
+	void _setVolume(double volume)  throws Exception
+	{
+		mSession.logError("setVolume: not implemented" );
+	}
+
+
+	void _setSpeed(double speed)  throws Exception
+	{
+		mSession.logError("setSpeed: not implemented" );
+	}
+
+
+	void _seekTo(long millisec)
+	{
+		mSession.logError("seekTo: not implemented" );
+	}
+
+
+	boolean _isPlaying()
+	{
+		return audioTrack.getPlayState () == AudioTrack.PLAYSTATE_PLAYING;
+	}
+
+
+	long _getDuration()
+	{
+		return 0;
+	}
+
+
+	long _getCurrentPosition()
+	{
+		return 0;
+	}
+
+	int feed(byte[] data) throws Exception
+	{
+		mSession.logError("feed error: not implemented");
+		return -1;
+	}
+
+}

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoPlayerEngineInterface.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoPlayerEngineInterface.java
@@ -1,0 +1,37 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+abstract class FlautoPlayerEngineInterface
+{
+	abstract void _startPlayer(String path, int sampleRate, int numChannels, int blockSize, FlautoPlayer theSession) throws Exception;
+	abstract void _stop();
+	abstract void _pausePlayer() throws Exception;
+	abstract void _resumePlayer() throws Exception;
+	abstract void _setVolume(double volume) throws Exception;
+	abstract void _setSpeed(double speed) throws Exception;
+	abstract void _seekTo(long millisec);
+	abstract boolean _isPlaying();
+	abstract long _getDuration();
+	abstract long _getCurrentPosition();
+	abstract int feed(byte[] data) throws Exception;
+	abstract void _play();
+
+
+}

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoPlayerMedia.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoPlayerMedia.java
@@ -1,0 +1,157 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import android.media.MediaPlayer;
+import android.media.PlaybackParams;
+import android.os.Build;
+import android.util.Log;
+
+//-------------------------------------------------------------------------------------------------------------
+
+
+class FlautoPlayerMedia extends FlautoPlayerEngineInterface
+{
+	MediaPlayer mediaPlayer = null;
+	FlautoPlayer flautoPlayer;
+
+	/* ctor */ FlautoPlayerMedia( FlautoPlayer theSession)
+	{
+		this.flautoPlayer = theSession;
+	}
+
+	void _startPlayer(String path,  int sampleRate, int numChannels, int blockSize, FlautoPlayer theSession) throws Exception
+ 	{
+		this.flautoPlayer = theSession;
+ 		mediaPlayer = new MediaPlayer();
+		if (path == null)
+		{
+			throw new Exception("path is NULL");
+		}
+		mediaPlayer.setDataSource(path);
+		final String pathFile = path;
+		mediaPlayer.setOnPreparedListener(mp -> {flautoPlayer.play(); flautoPlayer.onPrepared();});
+		mediaPlayer.setOnCompletionListener(mp -> flautoPlayer.onCompletion());
+		mediaPlayer.setOnErrorListener(flautoPlayer);
+		mediaPlayer.prepare();
+	}
+
+	void _play()
+	{
+		mediaPlayer.start();
+	}
+
+	int feed(byte[] data) throws Exception
+	{
+		throw new Exception("Cannot feed a Media Player");
+	}
+
+	void _setVolume(double volume)
+	{
+		float v = (float)volume;
+		mediaPlayer.setVolume ( v, v );
+	}
+
+	void _setSpeed(double speed)
+	{
+		float v = (float)speed;
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+			try {
+				PlaybackParams params = mediaPlayer.getPlaybackParams();
+				params.setSpeed(v);
+				mediaPlayer.setPlaybackParams(params);
+			} catch (Exception e) {
+				Log.e("_setSpeed", "_setSpeed: ", e);
+			}
+		}
+
+	}
+
+
+	void _stop() {
+		if (mediaPlayer == null)
+		{
+			return;
+		}
+
+		try
+		{
+			mediaPlayer.stop();
+		} catch (Exception e)
+		{
+		}
+
+		try
+		{
+			mediaPlayer.reset();
+		} catch (Exception e)
+		{
+		}
+
+		try
+		{
+			mediaPlayer.release();
+		} catch (Exception e)
+		{
+		}
+		mediaPlayer = null;
+
+	}
+
+
+
+	void _pausePlayer() throws Exception {
+		if (mediaPlayer == null) {
+			throw new Exception("pausePlayer()");
+		}
+		mediaPlayer.pause();
+	}
+
+	void _resumePlayer() throws Exception {
+		if (mediaPlayer == null) {
+			throw new Exception("resumePlayer");
+		}
+
+		if (mediaPlayer.isPlaying()) {
+			throw new Exception("resumePlayer");
+		}
+		// Is it really good ? // mediaPlayer.seekTo ( mediaPlayer.getCurrentPosition () );
+		mediaPlayer.start();
+	}
+
+	void _seekTo(long millisec)
+	{
+		mediaPlayer.seekTo ( (int)millisec );
+	}
+
+	boolean _isPlaying()
+	{
+		return mediaPlayer.isPlaying ();
+	}
+
+	long _getDuration()
+	{
+		return mediaPlayer.getDuration();
+	}
+
+	long _getCurrentPosition()
+	{
+		return mediaPlayer.getCurrentPosition();
+	}
+}

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorder.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorder.java
@@ -1,0 +1,370 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+
+import android.media.MediaRecorder;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+
+import java.io.*;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import com.dooboolab.TauEngine.Flauto.*;
+
+
+//-----------------------------------------------------------------------------------------------------------------------------------------------
+
+public class FlautoRecorder
+{
+	static boolean _isAndroidEncoderSupported[] = {
+		true, // DEFAULT
+		true, //Build.VERSION.SDK_INT >= 23,  // aacADTS
+		false, // opusOGG // ( Build.VERSION.SDK_INT < 29 )
+		false, // opusCAF
+		false, // MP3
+		false, // vorbisOGG // ( Build.VERSION.SDK_INT < 29 )
+		Build.VERSION.SDK_INT >= 21, // pcm16
+		Build.VERSION.SDK_INT >= 21, // pcm16WAV
+		false, // pcm16AIFF
+		false, // pcm16CAF
+		false, // flac
+		Build.VERSION.SDK_INT >= 23,  // aacMP4
+		Build.VERSION.SDK_INT >= 23,  // amrNB
+		Build.VERSION.SDK_INT >= 23,  // amrWB
+
+		false, // pcm8
+		false, // pcmFloat32
+		false, // pcmWebM
+		false, // opusWebM
+		false, // vorbisWebM
+	};
+
+
+	static boolean _isAudioRecorder[] = {
+		false, // DEFAULT
+		false, // aacADTS
+		false, // opusOGG
+		false, // opusCAF
+		false , // MP3
+		false, // vorbisOGG
+		true, // pcm16
+		true, // pcm16WAV
+		false, // pcm16AIFF
+		false, // pcm16CAF
+		false, // flac
+		false, // aacMP4
+		false, // amrNB
+		false, // amrWB
+		false, // pcm8
+		false, // pcmFloat32
+		false, // pcmWebM
+		false, // opusWebM
+		false, // vorbisWebM
+	};
+
+	int[] tabAudioSource =
+	{
+		MediaRecorder.AudioSource.DEFAULT,
+		MediaRecorder.AudioSource.MIC,
+		MediaRecorder.AudioSource.VOICE_DOWNLINK,
+		MediaRecorder.AudioSource.CAMCORDER,
+		MediaRecorder.AudioSource.REMOTE_SUBMIX,
+		MediaRecorder.AudioSource.UNPROCESSED,
+		MediaRecorder.AudioSource.VOICE_CALL,
+		MediaRecorder.AudioSource.VOICE_COMMUNICATION,
+		10, //MediaRecorder.AudioSource.VOICE_PERFORMANCE,,
+		MediaRecorder.AudioSource.VOICE_RECOGNITION,
+		MediaRecorder.AudioSource.VOICE_UPLINK,
+		MediaRecorder.AudioSource.DEFAULT, // bluetoothHFP,
+		MediaRecorder.AudioSource.DEFAULT, // headsetMic,
+		MediaRecorder.AudioSource.DEFAULT, // lineIn
+
+	};
+
+
+
+
+	final static int CODEC_OPUS   = 2;
+	final static int CODEC_VORBIS = 5;
+	static final String ERR_UNKNOWN           = "ERR_UNKNOWN";
+
+
+	static final String ERR_RECORDER_IS_NULL      = "ERR_RECORDER_IS_NULL";
+	static final String ERR_RECORDER_IS_RECORDING = "ERR_RECORDER_IS_RECORDING";
+
+
+	final static String             TAG                = "FlautoRecorder";
+	FlautoRecorderInterface recorder;
+	public Handler            recordHandler   ;
+	FlautoRecorderCallback m_callBack ;
+	private final ExecutorService taskScheduler = Executors.newSingleThreadExecutor ();
+	long mPauseTime = 0;
+	long mStartPauseTime = -1;
+	final private Handler          mainHandler = new Handler (Looper.getMainLooper ());
+	String m_path = null;
+
+	long subsDurationMillis = 0;
+
+	private      Runnable      recorderTicker;
+	t_RECORDER_STATE status = t_RECORDER_STATE.RECORDER_IS_STOPPED;
+
+	public FlautoRecorder ( FlautoRecorderCallback callback )
+	{
+		m_callBack = callback;
+	}
+
+
+	public boolean openRecorder ()
+	{
+		m_callBack.openRecorderCompleted(true);
+		return true;
+	}
+
+
+
+	public void closeRecorder ( )
+	{
+		stop();
+		status = t_RECORDER_STATE.RECORDER_IS_STOPPED;
+		m_callBack.closeRecorderCompleted(true);
+	}
+
+
+
+	public boolean isEncoderSupported ( t_CODEC codec)
+	{
+		boolean b      = _isAndroidEncoderSupported[ codec.ordinal() ];
+		return b;
+	}
+
+
+	public t_RECORDER_STATE getRecorderState()
+	{
+		return status;
+	}
+
+
+
+	public boolean deleteRecord(String radical)
+	{
+		String path = Flauto.temporayFile(radical);
+		File fdelete = new File(path);
+		if (fdelete.exists())
+		{
+			if (fdelete.delete())
+			{
+				return true;
+			} else
+			{
+				return false;
+			}
+		} else
+			return false;
+
+	}
+
+
+	void cancelTimer()
+	{
+		if (recordHandler != null)
+			recordHandler.removeCallbacksAndMessages(null);
+		recordHandler = null;
+
+	}
+
+	void setTimer(long duration)
+	{
+		cancelTimer();
+		subsDurationMillis = duration;
+		if (recorder == null || duration == 0)
+			return;
+		final long systemTime = SystemClock.elapsedRealtime();
+		recordHandler      = new Handler ();
+		recorderTicker = ( () ->
+		{
+			mainHandler.post(new Runnable()
+			{
+				@Override
+				public void run() {
+
+					long time = SystemClock.elapsedRealtime() - systemTime - mPauseTime;
+					try {
+						double db = 0.0;
+						if (recorder != null) {
+							double maxAmplitude = recorder.getMaxAmplitude();
+
+							// Calculate db based on the following article.
+							// https://stackoverflow.com/questions/10655703/what-does-androids-getmaxamplitude-function-for-the-mediarecorder-actually-gi
+							//
+							double ref_pressure = 51805.5336;
+							double p = maxAmplitude / ref_pressure;
+							double p0 = 0.0002;
+
+							db = 20.0 * Math.log10(p / p0);
+
+							// if the microphone is off we get 0 for the amplitude which causes
+							// db to be infinite.
+							if (Double.isInfinite(db)) {
+								db = 0.0;
+							}
+
+						}
+
+
+						m_callBack.updateRecorderProgressDbPeakLevel(db, time);
+						if (recordHandler != null)
+							recordHandler.postDelayed(recorderTicker, subsDurationMillis);
+					} catch (Exception e) {
+						logDebug (  " Exception: " + e.toString());
+					}
+				}
+			});
+
+
+		} );
+		recordHandler.post ( recorderTicker );
+
+	}
+
+	public boolean startRecorder
+	(
+		t_CODEC 						codec		    ,
+		Integer                         sampleRate          ,
+		Integer                         numChannels         ,
+		Integer                         bitRate             ,
+		String                     		path                ,
+		t_AUDIO_SOURCE                  _audioSource        ,
+		boolean 						toStream
+	)
+	{
+		int  audioSource         = tabAudioSource[_audioSource.ordinal()];
+		
+		// logError (  "I hope this code is running" );
+		// lsdkfjlskdfj;
+		
+		mPauseTime = 0;
+		mStartPauseTime = -1;
+		stop(); // To start a new clean record
+		m_path = null;
+		if (_isAudioRecorder[codec.ordinal()])
+		{
+				if (numChannels != 1)
+				{
+						logError (  "The number of channels supported is actually only 1" );
+						return false;
+				}
+				recorder = new FlautoRecorderEngine();
+		} else
+		{
+				path = Flauto.getPath(path);
+				m_path = path;
+				recorder = new FlautoRecorderMedia(m_callBack);
+		}
+		try
+		{
+				recorder._startRecorder( numChannels, sampleRate, bitRate, codec, path, audioSource, this );
+				if (subsDurationMillis > 0)
+						setTimer(subsDurationMillis);
+
+		} catch ( Exception e )
+		{
+				logError (  "Error starting recorder" + e.getMessage() );
+				return false;
+		}
+		status = t_RECORDER_STATE.RECORDER_IS_RECORDING;
+		m_callBack.startRecorderCompleted(true);
+		return true;
+	}
+
+	public void recordingData(byte[] data)
+	{
+		m_callBack.recordingData(data);
+	}
+
+	void stop()
+	{
+		try {
+				cancelTimer();
+				if (recorder != null)
+				recorder._stopRecorder();
+		} catch (Exception e)
+		{
+
+		}
+		recorder = null;
+		status = t_RECORDER_STATE.RECORDER_IS_STOPPED;
+
+	}
+
+	public void stopRecorder ( )
+	{
+			stop();
+			m_callBack.stopRecorderCompleted(true, m_path);
+	}
+
+	public void pauseRecorder()
+	{
+			cancelTimer();
+			recorder.pauseRecorder( );
+			mStartPauseTime = SystemClock.elapsedRealtime ();
+			status = t_RECORDER_STATE.RECORDER_IS_PAUSED;
+			m_callBack.pauseRecorderCompleted(true);
+	}
+
+	public void resumeRecorder( )
+	{
+			setTimer(subsDurationMillis);
+			recorder.resumeRecorder();
+			if (mStartPauseTime >= 0)
+					mPauseTime += SystemClock.elapsedRealtime () - mStartPauseTime;
+			mStartPauseTime = -1;
+			status = t_RECORDER_STATE.RECORDER_IS_RECORDING;
+			m_callBack.resumeRecorderCompleted(true);
+	}
+
+	public void setSubscriptionDuration (int duration)
+	{
+			this.subsDurationMillis = duration;
+			if (recorder != null)
+					setTimer(subsDurationMillis);
+	}
+
+	public String temporayFile(String radical)
+	{
+		return Flauto.temporayFile(radical);
+	}
+
+
+
+	void logDebug (String msg)
+	{
+		m_callBack.log ( t_LOG_LEVEL.DBG , msg);
+	}
+
+
+	void logError (String msg)
+	{
+		m_callBack.log ( t_LOG_LEVEL.ERROR , msg);
+	}
+
+}

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderCallback.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderCallback.java
@@ -1,0 +1,35 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import com.dooboolab.TauEngine.Flauto.*;
+
+public interface FlautoRecorderCallback
+{
+        public abstract void openRecorderCompleted(boolean success);
+        public abstract void closeRecorderCompleted(boolean success);
+        public abstract void startRecorderCompleted(boolean success);
+        public abstract void stopRecorderCompleted(boolean success, String url);
+        public abstract void pauseRecorderCompleted(boolean success);
+        public abstract void resumeRecorderCompleted(boolean success);
+        public abstract void updateRecorderProgressDbPeakLevel(double normalizedPeakLevel, long duration);
+        public abstract void recordingData ( byte[] data);
+        abstract public void log(t_LOG_LEVEL level, String msg);
+
+}

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderEngine.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderEngine.java
@@ -1,0 +1,308 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import android.media.AudioFormat;
+import android.media.AudioRecord;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ShortBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Arrays;
+
+import com.dooboolab.TauEngine.Flauto.*;
+
+
+public class FlautoRecorderEngine
+		implements FlautoRecorderInterface
+{
+	private AudioRecord recorder = null;
+	//private Thread recordingThread = null;
+	private boolean isRecording = false;
+	private double maxAmplitude = 0;
+	String filePath;
+	int totalBytes = 0;
+	t_CODEC codec;
+	Runnable p;
+	FlautoRecorder session = null;
+	FileOutputStream outputStream = null;
+	final private Handler mainHandler = new Handler (Looper.getMainLooper ());
+
+
+
+
+	private short getShort(byte argB1, byte argB2) {
+		return (short)(argB1 | (argB2 << 8));
+	}
+
+	private void writeAudioDataToFile(t_CODEC codec, int sampleRate, String aFilePath) throws IOException
+	{
+		// Write the output audio in byte
+		System.out.println("---> writeAudioDataToFile");
+		totalBytes = 0;
+		outputStream = null;
+		filePath = aFilePath;
+		if (filePath != null)
+		{
+			outputStream = new FileOutputStream(filePath);
+
+			if (codec == t_CODEC.pcm16WAV) {
+				FlautoWaveHeader header = new FlautoWaveHeader
+						(
+								FlautoWaveHeader.FORMAT_PCM,
+								(short) 1, // numChannels
+								sampleRate,
+								(short) 16,
+								100000 // total number of bytes
+
+						);
+				header.write(outputStream);
+			}
+		}
+		System.out.println("<--- writeAudioDataToFile");
+	}
+
+	void closeAudioDataFile(String filepath) throws Exception
+	{
+
+		if (outputStream != null) {
+			outputStream.close();
+			if (codec == t_CODEC.pcm16WAV) {
+				RandomAccessFile fh = new RandomAccessFile(filePath, "rw");
+				fh.seek(4);
+				int x = totalBytes + 36;
+				fh.write(x >> 0);
+				fh.write(x >> 8);
+				fh.write(x >> 16);
+				fh.write(x >> 24);
+
+
+				fh.seek(FlautoWaveHeader.HEADER_LENGTH - 4);
+				fh.write(totalBytes >> 0);
+				fh.write(totalBytes >> 8);
+				fh.write(totalBytes >> 16);
+				fh.write(totalBytes >> 24);
+				fh.close();
+			}
+		}
+
+	}
+
+	int[] tabCodec =
+			{
+					AudioFormat.ENCODING_DEFAULT, // DEFAULT
+					AudioFormat.ENCODING_AAC_LC, // aacADTS
+					0, // opusOGG
+					0, // opusCAF
+					AudioFormat.ENCODING_MP3, // MP3 // Not used
+					0, // vorbisOGG
+					AudioFormat.ENCODING_PCM_16BIT, // pcm16
+					AudioFormat.ENCODING_PCM_16BIT, // pcm16WAV
+					0, // pcm16AIFF
+					0, // pcm16CAF
+					0, // flac
+					0, // aacMP4
+					0, // amrNB
+					0, // amrWB
+			};
+
+
+	int writeData(int bufferSize)
+	{
+		int n = 0;
+		int r = 0;
+		while (isRecording ) {
+			//ShortBuffer shortBuffer = ShortBuffer.allocate(bufferSize/2);
+			ByteBuffer byteBuffer = ByteBuffer.allocate(bufferSize);
+			try {
+				// gets the voice output from microphone to byte format
+				if ( Build.VERSION.SDK_INT >= 23 )
+				{
+					n = recorder.read(byteBuffer.array(), 0, bufferSize, AudioRecord.READ_NON_BLOCKING);
+
+				}
+				else
+				{
+					n = recorder.read(byteBuffer.array(), 0, bufferSize);
+				}
+				final int ln = n;//2 * n;
+
+				if (n > 0) {
+					totalBytes += n;
+					r += n;
+					if (outputStream != null) {
+						outputStream.write(byteBuffer.array(), 0, ln);
+					} else {
+						mainHandler.post(new Runnable() {
+							@Override
+							public void run() {
+
+								session.recordingData(Arrays.copyOfRange(byteBuffer.array(), 0, ln));
+							}
+						});
+					}
+					for (int i = 0; i < n / 2; ++i) {
+						short curSample = getShort(byteBuffer.array()[i * 2], byteBuffer.array()[i * 2 + 1]);
+						if (curSample > maxAmplitude) {
+							maxAmplitude = curSample;
+						}
+					}
+				} else
+				{
+					break;
+				}
+				if ( Build.VERSION.SDK_INT < 23 ) // We must break the loop, because n is always 1024 (READ_BLOCKING_MODE)
+					break;
+			} catch (Exception e) {
+				System.out.println(e);
+				break;
+			}
+		}
+		if (isRecording)
+			mainHandler.post(p);
+
+		return r;
+
+	}
+
+
+	public void _startRecorder
+			(
+					Integer numChannels,
+					Integer sampleRate,
+					Integer bitRate,
+					t_CODEC theCodec,
+					String path,
+					int audioSource,
+					FlautoRecorder theSession
+
+			) throws Exception
+	{
+		if ( Build.VERSION.SDK_INT < 21)
+			throw new Exception ("Need at least SDK 21");
+		session = theSession;
+		codec = theCodec;
+		int channelConfig = (numChannels == 1) ? AudioFormat.CHANNEL_IN_MONO : AudioFormat.CHANNEL_IN_STEREO;
+		int audioFormat = tabCodec[codec.ordinal()];
+		int bufferSize = AudioRecord.getMinBufferSize
+				(
+						sampleRate,
+						channelConfig,
+						tabCodec[codec.ordinal()]
+				) * 2;
+
+
+		recorder = new AudioRecord( 	audioSource,
+				sampleRate,
+				channelConfig,
+				audioFormat,
+				bufferSize
+		);
+
+		if (recorder.getState() == AudioRecord.STATE_INITIALIZED)
+		{
+			recorder.startRecording();
+			isRecording = true;
+			try {
+				writeAudioDataToFile(codec, sampleRate, path);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			p = new Runnable() {
+				@Override
+				public void run() {
+
+					if (isRecording) {
+						int n = writeData(bufferSize);
+
+					}
+				}
+			};
+			mainHandler.post(p);
+		} else
+		{
+			throw new Exception("Cannot initialize the AudioRecord");
+		}
+
+	}
+
+	public void _stopRecorder (  ) throws Exception
+	{
+		if (null != recorder)
+		{
+			try
+			{
+				recorder.stop();
+			} catch ( Exception e )
+			{
+			}
+
+			try
+			{
+				isRecording = false;
+				recorder.release();
+			} catch ( Exception e )
+			{
+			}
+			recorder = null;
+		}
+		closeAudioDataFile(filePath);
+	}
+
+	public boolean pauseRecorder( )
+	{
+		try
+		{
+			recorder.stop();
+			return true;
+		} catch(Exception e)
+		{
+			e.printStackTrace();
+			return false;
+		}
+	}
+
+	public boolean resumeRecorder(  )
+	{
+		try
+		{
+			recorder.startRecording();
+			return true;
+		} catch(Exception e)
+		{
+			e.printStackTrace();
+			return false;
+		}
+	}
+
+	public double getMaxAmplitude ()
+	{
+		double r = maxAmplitude;
+		maxAmplitude = 0;
+		return r;
+	}
+
+}

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderInterface.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderInterface.java
@@ -1,0 +1,44 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import java.io.IOException;
+import com.dooboolab.TauEngine.Flauto.t_CODEC;
+
+
+public interface FlautoRecorderInterface
+{
+	public void _startRecorder
+		(
+			Integer numChannels,
+			Integer sampleRate,
+			Integer bitRate,
+			t_CODEC codec,
+			String path,
+			int audioSource,
+			FlautoRecorder session
+		)
+		throws
+		IOException, Exception;
+	public void _stopRecorder (  ) throws Exception;
+	public boolean pauseRecorder( );
+	public boolean resumeRecorder(  );
+	public double getMaxAmplitude ();
+
+}

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderMedia.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderMedia.java
@@ -1,0 +1,284 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright 2018, 2019, 2020, 2021 Dooboolab.
+ *
+ * This file is part of Flutter-Sound.
+ *
+ * Flutter-Sound is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public License version 2 (MPL2.0),
+ * as published by the Mozilla organization.
+ *
+ * Flutter-Sound is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MPL General Public License for more details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import android.content.pm.PackageManager;
+import android.media.MediaRecorder;
+import android.os.Build;
+import androidx.core.content.ContextCompat;
+import java.io.IOException;
+import com.dooboolab.TauEngine.Flauto.t_CODEC;
+import static android.Manifest.permission.RECORD_AUDIO;
+
+
+public class FlautoRecorderMedia
+	implements FlautoRecorderInterface
+{
+	FlautoRecorderCallback m_callback;
+	final static String             TAG                = "SoundMediaRecorder";
+
+	static int codecArray[] =
+	{
+			MediaRecorder.AudioEncoder.DEFAULT,
+			MediaRecorder.AudioEncoder.AAC,
+			MediaRecorder.AudioEncoder.OPUS,
+			0, // CODEC_CAF_OPUS (specific Apple)
+			0,// CODEC_MP3 (not implemented)
+			MediaRecorder.AudioEncoder.VORBIS,
+			7, // MediaRecorder.AudioEncoder.DEFAULT // CODEC_PCM (not implemented)
+			0, // wav
+			0, // aiff
+			0, // pcmCAF
+			0, // flac
+			MediaRecorder.AudioEncoder.AAC, // aacMP4
+			MediaRecorder.AudioEncoder.AMR_NB,
+			MediaRecorder.AudioEncoder.AMR_WB,
+			0, // pcm8
+			0, // pcmFloat32
+			0, // pcmWebM
+			MediaRecorder.AudioEncoder.OPUS, // opusWebM
+			MediaRecorder.AudioEncoder.VORBIS, // vorbisWebM
+	};
+
+
+
+	static int formatsArray[] =
+	{
+			MediaRecorder.OutputFormat.DEFAULT // DEFAULT
+			, MediaRecorder.OutputFormat.AAC_ADTS // CODEC_AAC
+			, MediaRecorder.OutputFormat.OGG // CODEC_OPUS
+			, 0 // CODEC_CAF_OPUS (this is apple specific)
+			, 0 // CODEC_MP3
+			, MediaRecorder.OutputFormat.OGG // CODEC_VORBIS
+			, 0 //ENCODING_PCM_16BIT// CODEC_PCM
+			, 0 // wav
+			, 0 // aiff
+			, 0 // pcmCAF
+			, 0 // flac
+			, MediaRecorder.OutputFormat.MPEG_4 // aacMP4
+			, MediaRecorder.OutputFormat.AMR_NB
+			, MediaRecorder.OutputFormat.AMR_WB
+			, 0 // pcm8
+			, 0 // pcmFloat32
+			, MediaRecorder.OutputFormat.WEBM // pcmWebM
+			, MediaRecorder.OutputFormat.WEBM // opusWebM
+			, MediaRecorder.OutputFormat.WEBM // vorbisWebM
+	};
+
+	static       String pathArray[]               =
+	{
+			"sound.fs" // DEFAULT
+			, "sound.aac" // CODEC_AAC
+			, "sound.opus" // CODEC_OPUS
+			, "sound_opus.caf" // CODEC_CAF_OPUS (this is apple specific)
+			, "sound.mp3" // CODEC_MP3
+			, "sound.ogg" // CODEC_VORBIS
+			, "sound.pcm" // CODEC_PCM
+			, "sound.wav" // pcm16WAV
+			, "sound.aiff" // pcm16AIFF
+			, "sound_pcm.caf" // pcm16CAF
+			, "sound.flac" // flac
+			, "sound.mp4" // aacMP4
+			, "sound.amr" // amrNB
+			, "sound.amr" // amrWB
+			, "sound.pcm" // pcm8
+			, "sound.pcm" // pcmFloat32
+			, "sound.webm" // pcmWebM
+			, "sound.opus" // opusWebM
+			, "sound.vorbis" // vorbisWebM
+
+	};
+
+
+	MediaRecorder mediaRecorder;
+
+	public /* ctor */ FlautoRecorderMedia(FlautoRecorderCallback cb)
+	{
+		m_callback = cb;
+	}
+
+	public boolean CheckPermissions()
+	{
+		int result1 = ContextCompat.checkSelfPermission(Flauto.androidContext, RECORD_AUDIO);
+		return result1 == PackageManager.PERMISSION_GRANTED;
+	}
+
+
+	public void _startRecorder
+		(
+			Integer numChannels,
+			Integer sampleRate,
+			Integer bitRate,
+			t_CODEC codec,
+			String path,
+			int audioSource,
+			FlautoRecorder session
+		)
+		throws
+		IOException, Exception
+	{
+		// The caller must be allowed to specify its path. We must not change it here
+		// path = PathUtils.getDataDirectory(reg.context()) + "/" + path; // SDK 29 :
+		// you may not write in getExternalStorageDirectory()
+
+		if ( mediaRecorder != null )
+		{
+			mediaRecorder.reset ();
+		} else
+		{
+			mediaRecorder = new MediaRecorder ();
+		}
+
+		if (!CheckPermissions())
+		{
+			throw new Exception("Check Permission: Recording permission is not granted");
+		}
+
+		try
+		{
+				mediaRecorder.reset();
+				mediaRecorder.setAudioSource (audioSource );
+				int androidEncoder      = codecArray[ codec.ordinal () ];
+				int androidOutputFormat = formatsArray[ codec.ordinal () ];
+				mediaRecorder.setOutputFormat ( androidOutputFormat );
+
+				if ( path == null )
+				{
+					path = pathArray[ codec.ordinal () ];
+				}
+
+				mediaRecorder.setOutputFile ( path );
+				mediaRecorder.setAudioEncoder ( androidEncoder );
+
+				if ( numChannels != null )
+				{
+					mediaRecorder.setAudioChannels ( numChannels );
+				}
+
+				if ( sampleRate != null )
+				{
+					mediaRecorder.setAudioSamplingRate ( sampleRate );
+				}
+
+				// If bitrate is defined, then use it, otherwise use the OS default
+				if ( bitRate != null )
+				{
+					mediaRecorder.setAudioEncodingBitRate ( bitRate );
+				}
+
+				mediaRecorder.prepare ();
+				mediaRecorder.start ();
+
+			}
+		catch ( Exception e )
+		{
+				m_callback.log(Flauto.t_LOG_LEVEL.ERROR,  "Exception: " );
+				//
+				try
+				{
+					_stopRecorder( );
+
+				} catch (Exception e2)
+				{
+
+				}
+				throw(e);
+		}
+	}
+
+	public void _stopRecorder (  )
+	{
+		// This remove all pending runnables
+
+		if ( mediaRecorder == null )
+		{
+			m_callback.log(Flauto.t_LOG_LEVEL.DBG,  "mediaRecorder is null" );
+			return ;
+		}
+		try
+		{
+			if ( Build.VERSION.SDK_INT >= 24 )
+			{
+
+				try
+				{
+					mediaRecorder.resume(); // This is stupid, but cannot reset() if Pause Mode !
+				}
+				catch ( Exception e )
+				{
+				}
+			}
+			mediaRecorder.stop();
+			mediaRecorder.reset();
+			mediaRecorder.release();
+			mediaRecorder = null;
+		} catch  ( Exception e )
+		{
+			m_callback.log(Flauto.t_LOG_LEVEL.ERROR,  "Error Stop Recorder" );
+
+		}
+	}
+
+
+	public boolean pauseRecorder(  )
+	{
+		if ( mediaRecorder == null )
+		{
+			m_callback.log(Flauto.t_LOG_LEVEL.DBG,   "mediaRecorder is null" );
+
+			return false;
+		}
+		if ( Build.VERSION.SDK_INT < 24 )
+		{
+			m_callback.log(Flauto.t_LOG_LEVEL.DBG,  "Pause/Resume needs at least Android API 24");
+			return false;
+		} else
+		{
+			mediaRecorder.pause();
+			return true;
+		}
+	}
+
+
+	public boolean resumeRecorder( )
+	{
+		if ( mediaRecorder == null )
+		{
+			m_callback.log(Flauto.t_LOG_LEVEL.DBG,  "mediaRecorder is null" );
+			//result.error ( TAG, "Recorder is closed", "\"Recorder is closed\"" );
+			return false;
+		}
+		if ( Build.VERSION.SDK_INT < 24 )
+		{
+			m_callback.log(Flauto.t_LOG_LEVEL.DBG,  "Pause/Resume needs at least Android API 24");
+			//result.error ( TAG, "Bad Android API level", "\"Pause/Resume needs at least Android API 24\"" );
+			return false;
+		} else
+		{
+			mediaRecorder.resume();
+
+			return true;
+		}
+	}
+	public double getMaxAmplitude ()
+	{
+		return mediaRecorder.getMaxAmplitude();
+	}
+
+}

--- a/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoWaveHeader.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/TauEngine/FlautoWaveHeader.java
@@ -1,0 +1,260 @@
+package com.dooboolab.TauEngine;
+/*
+ * Copyright (C) 2009 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+/**
+ * This class represents the header of a WAVE format audio file, which usually
+ * have a .wav suffix.  The following integer valued fields are contained:
+ * <ul>
+ * <li> format - usually PCM, ALAW or ULAW.
+ * <li> numChannels - 1 for mono, 2 for stereo.
+ * <li> sampleRate - usually 8000, 11025, 16000, 22050, or 44100 hz.
+ * <li> bitsPerSample - usually 16 for PCM, 8 for ALAW, or 8 for ULAW.
+ * <li> numBytes - size of audio data after this header, in bytes.
+ * </ul>
+ *
+ * Not yet ready to be supported, so
+ * at-hide
+ */
+public class FlautoWaveHeader {
+
+	// follows WAVE format in http://ccrma.stanford.edu/courses/422/projects/WaveFormat
+	private static final String TAG = "WaveHeader";
+
+	public static final int HEADER_LENGTH = 44;
+
+	/** Indicates PCM format. */
+	public static final short FORMAT_PCM = 1;
+	/** Indicates ALAW format. */
+	public static final short FORMAT_ALAW = 6;
+	/** Indicates ULAW format. */
+	public static final short FORMAT_ULAW = 7;
+
+	private short mFormat;
+	private short mNumChannels;
+	private int mSampleRate;
+	private short mBitsPerSample;
+	private int mNumBytes;
+
+	/**
+	 * Construct a WaveHeader, with all fields defaulting to zero.
+	 */
+	public FlautoWaveHeader() {
+	}
+
+	/**
+	 * Construct a WaveHeader, with fields initialized.
+	 * @param format format of audio data,
+	 * one of {@link #FORMAT_PCM}, {@link #FORMAT_ULAW}, or {@link #FORMAT_ALAW}.
+	 * @param numChannels 1 for mono, 2 for stereo.
+	 * @param sampleRate typically 8000, 11025, 16000, 22050, or 44100 hz.
+	 * @param bitsPerSample usually 16 for PCM, 8 for ULAW or 8 for ALAW.
+	 * @param numBytes size of audio data after this header, in bytes.
+	 */
+	public FlautoWaveHeader(short format, short numChannels, int sampleRate, short bitsPerSample, int numBytes) {
+		mFormat = format;
+		mSampleRate = sampleRate;
+		mNumChannels = numChannels;
+		mBitsPerSample = bitsPerSample;
+		mNumBytes = numBytes;
+	}
+
+	/**
+	 * Get the format field.
+	 * @return format field,
+	 * one of {@link #FORMAT_PCM}, {@link #FORMAT_ULAW}, or {@link #FORMAT_ALAW}.
+	 */
+	public short getFormat() {
+		return mFormat;
+	}
+
+	/**
+	 * Set the format field.
+	 * @param format
+	 * one of {@link #FORMAT_PCM}, {@link #FORMAT_ULAW}, or {@link #FORMAT_ALAW}.
+	 * @return reference to this WaveHeader instance.
+	 */
+	public FlautoWaveHeader setFormat(short format) {
+		mFormat = format;
+		return this;
+	}
+
+	/**
+	 * Get the number of channels.
+	 * @return number of channels, 1 for mono, 2 for stereo.
+	 */
+	public short getNumChannels() {
+		return mNumChannels;
+	}
+
+	/**
+	 * Set the number of channels.
+	 * @param numChannels 1 for mono, 2 for stereo.
+	 * @return reference to this WaveHeader instance.
+	 */
+	public FlautoWaveHeader setNumChannels(short numChannels) {
+		mNumChannels = numChannels;
+		return this;
+	}
+
+	/**
+	 * Get the sample rate.
+	 * @return sample rate, typically 8000, 11025, 16000, 22050, or 44100 hz.
+	 */
+	public int getSampleRate() {
+		return mSampleRate;
+	}
+
+	/**
+	 * Set the sample rate.
+	 * @param sampleRate sample rate, typically 8000, 11025, 16000, 22050, or 44100 hz.
+	 * @return reference to this WaveHeader instance.
+	 */
+	public FlautoWaveHeader setSampleRate(int sampleRate) {
+		mSampleRate = sampleRate;
+		return this;
+	}
+
+	/**
+	 * Get the number of bits per sample.
+	 * @return number of bits per sample,
+	 * usually 16 for PCM, 8 for ULAW or 8 for ALAW.
+	 */
+	public short getBitsPerSample() {
+		return mBitsPerSample;
+	}
+
+	/**
+	 * Set the number of bits per sample.
+	 * @param bitsPerSample number of bits per sample,
+	 * usually 16 for PCM, 8 for ULAW or 8 for ALAW.
+	 * @return reference to this WaveHeader instance.
+	 */
+	public FlautoWaveHeader setBitsPerSample(short bitsPerSample) {
+		mBitsPerSample = bitsPerSample;
+		return this;
+	}
+
+	/**
+	 * Get the size of audio data after this header, in bytes.
+	 * @return size of audio data after this header, in bytes.
+	 */
+	public int getNumBytes() {
+		return mNumBytes;
+	}
+
+	/**
+	 * Set the size of audio data after this header, in bytes.
+	 * @param numBytes size of audio data after this header, in bytes.
+	 * @return reference to this WaveHeader instance.
+	 */
+	public FlautoWaveHeader setNumBytes(int numBytes) {
+		mNumBytes = numBytes;
+		return this;
+	}
+
+	/**
+	 * Read and initialize a WaveHeader.
+	 * @param in {@link java.io.InputStream} to read from.
+	 * @return number of bytes consumed.
+	 * @throws IOException
+	 */
+	public int read(InputStream in) throws IOException {
+		/* RIFF header */
+		readId(in, "RIFF");
+		int numBytes = readInt(in) - 36;
+		readId(in, "WAVE");
+		/* fmt chunk */
+		readId(in, "fmt ");
+		if (16 != readInt(in)) throw new IOException("fmt chunk length not 16");
+		mFormat = readShort(in);
+		mNumChannels = readShort(in);
+		mSampleRate = readInt(in);
+		int byteRate = readInt(in);
+		short blockAlign = readShort(in);
+		mBitsPerSample = readShort(in);
+		if (byteRate != mNumChannels * mSampleRate * mBitsPerSample / 8) {
+			throw new IOException("fmt.ByteRate field inconsistent");
+		}
+		if (blockAlign != mNumChannels * mBitsPerSample / 8) {
+			throw new IOException("fmt.BlockAlign field inconsistent");
+		}
+		/* data chunk */
+		readId(in, "data");
+		mNumBytes = readInt(in);
+
+		return HEADER_LENGTH;
+	}
+	private static void readId(InputStream in, String id) throws IOException {
+		for (int i = 0; i < id.length(); i++) {
+			if (id.charAt(i) != in.read()) throw new IOException( id + " tag not present");
+		}
+	}
+	private static int readInt(InputStream in) throws IOException {
+		return in.read() | (in.read() << 8) | (in.read() << 16) | (in.read() << 24);
+	}
+	private static short readShort(InputStream in) throws IOException {
+		return (short)(in.read() | (in.read() << 8));
+	}
+	/**
+	 * Write a WAVE file header.
+	 * @param out {@link java.io.OutputStream} to receive the header.
+	 * @return number of bytes written.
+	 * @throws IOException
+	 */
+	public int write(OutputStream out) throws IOException {
+		/* RIFF header */
+		writeId(out, "RIFF");
+		writeInt(out, 36 + mNumBytes);
+		writeId(out, "WAVE");
+		/* fmt chunk */
+		writeId(out, "fmt ");
+		writeInt(out, 16);
+		writeShort(out, mFormat);
+		writeShort(out, mNumChannels);
+		writeInt(out, mSampleRate);
+		writeInt(out, mNumChannels * mSampleRate * mBitsPerSample / 8);
+		writeShort(out, (short)(mNumChannels * mBitsPerSample / 8));
+		writeShort(out, mBitsPerSample);
+		/* data chunk */
+		writeId(out, "data");
+		writeInt(out, mNumBytes);
+
+		return HEADER_LENGTH;
+	}
+	private static void writeId(OutputStream out, String id) throws IOException {
+		for (int i = 0; i < id.length(); i++) out.write(id.charAt(i));
+	}
+	private static void writeInt(OutputStream out, int val) throws IOException {
+		out.write(val >> 0);
+		out.write(val >> 8);
+		out.write(val >> 16);
+		out.write(val >> 24);
+	}
+	private static void writeShort(OutputStream out, short val) throws IOException {
+		out.write(val >> 0);
+		out.write(val >> 8);
+	}
+
+	@Override
+	public String toString() {
+		return String.format(
+			"WaveHeader format=%d numChannels=%d sampleRate=%d bitsPerSample=%d numBytes=%d",
+			mFormat, mNumChannels, mSampleRate, mBitsPerSample, mNumBytes);
+	}
+}


### PR DESCRIPTION
⚠️ This code (see [2dcf3d0](https://github.com/tokotutor/flutter_sound/pull/1/commits/2dcf3d0009a51e5983a333b1b5bb4936cdfa26a0) for relevant changes) does not seem to work!

Inspired by:
- https://developer.android.com/guide/topics/connectivity/ble-audio/audio-recording#java

I confirmed via `recorder.getPreferredDevice()` that the preferred device is being correctly set, but then looking at some system logcat output, seems like the pref to use the bluetooth device is being ignored:


```
2023-10-24 16:30:09.957   939-3528  audio_hw                android.hardware.audio.service       D  prepare audio-record
2023-10-24 16:30:09.957   939-3528  audio_hw                android.hardware.audio.service       D  audio-record:
2023-10-24 16:30:09.957   939-3528  audio_hw                android.hardware.audio.service       D  tx:
2023-10-24 16:30:09.957   939-3528  audio_hw                android.hardware.audio.service       D    #0: IN_HANDSET_MIC_BE_CFG 0
2023-10-24 16:30:09.957   939-3528  audio_route             android.hardware.audio.service       D  Apply path: handset-mic
2023-10-24 16:30:09.958   939-3528  audio_hw_aoc_route      android.hardware.audio.service       D  handset-mic 1
2023-10-24 16:30:09.958   939-3528  audio_hw_soundtrigger   android.hardware.audio.service       D  st_comm_aud_event_monitor:codec dev:30 active
2023-10-24 16:30:09.958   939-3528  audio_hw_aoc            android.hardware.audio.service       I  Mode Ambient is already selected
2023-10-24 16:30:09.958   939-3528  audio_route             android.hardware.audio.service       D  Apply path: audio-recordC
2023-10-24 16:30:09.958   939-3528  audio_hw_aoc_route      android.hardware.audio.service       D  audio-recordC 1
2023-10-24 16:30:09.958   939-3528  audio_route             android.hardware.audio.service       D  Apply path: handset-mic-post
2023-10-24 16:30:09.958   939-3528  audio_hw_aoc_route      android.hardware.audio.service       D  handset-mic-post 1
```

TBH It seems like Android Bluetooth Audio APIs are not very good; relevant APIs are still being added in -- for example, some new BLE/communications enum values/methods were released only in API level 31/32, late 2021/early 2022

### Notes on attempting to modify files in `flutter_sound_core` locally

I couldn't seem to get local flutter_sound with `:flutter_sound_core` working via gradle 😕

It should work by replacing the
```
implementation 'com.github.canardoux:flutter_sound_core:9.2.13'
```
with
```
implementation project(':flutter_sound_core')
```
in [build.gradle](https://github.com/tokotutor/flutter_sound/blob/toko/flutter_sound/android/build.gradle)

and adding
```
include ':flutter_sound_core'  
project(':flutter_sound_core').projectDir = file('../../flutter_sound_core/android')
```
to [settings.gradle](https://github.com/tokotutor/flutter_sound/blob/toko/flutter_sound/android/settings.gradle)

but that didn't work, sooooo I just copied the Android source files from flutter_sound_core into this repo, which seemed to work! (see c415dd4fd6d7075801bacc0d640c3b8290e073aa)

### Appendix: can we do this without native code modifications?

Multiple people have asked on StackOverflow how to record audio from a Bluetooth headset (https://stackoverflow.com/questions/75637854/how-can-i-use-bluetooth-mic-in-flutter, https://stackoverflow.com/questions/57128799/how-to-record-audio-from-bluetooth-headphones-in-flutter-app), with no answers, so I'm pretty confident there's no way to do it without native code modifications
